### PR TITLE
Multi selectors throughout separator ',' doesn't work

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,21 +5,25 @@ var insert = require('insert-css')
 var globals = ['*', 'body', 'html']
 
 module.exports = function(scope, style) {
-  var id = cuid.slug()
-  scope.setAttribute('data-scoped-css', id)
+  var id = cuid.slug();
+  scope.setAttribute('data-scoped-css', id);
 
-  var o = css.parse(style)
+  var o = css.parse(style);
   o.stylesheet.rules.forEach(function(rule, i) {
     if (o.stylesheet.rules[i].type !== 'rule') return
 
-    var s = o.stylesheet.rules[i].selectors[0]
-    var globalAttr = false
-    if (globals.indexOf(s) > -1) globalAttr = true
-    var selector = globalAttr ?
+    var selectors = o.stylesheet.rules[i].selectors;
+    var globalAttr = false;
+
+    selectors.forEach(function(s,idx){
+      if (globals.indexOf(s) > -1) globalAttr = true
+      var selector = globalAttr ?
       s + ' [data-scoped-css="' + id + '"]'
-      : '[data-scoped-css="' + id + '"] ' + s
-    o.stylesheet.rules[i].selectors[0] = selector
+          : '[data-scoped-css="' + id + '"] ' + s;
+      o.stylesheet.rules[i].selectors[idx] = selector;
+    })
+
   })
 
-  insert(css.stringify(o))
+  insert(css.stringify(o));
 }

--- a/index.js
+++ b/index.js
@@ -5,25 +5,24 @@ var insert = require('insert-css')
 var globals = ['*', 'body', 'html']
 
 module.exports = function(scope, style) {
-  var id = cuid.slug();
-  scope.setAttribute('data-scoped-css', id);
+  var id = cuid.slug()
+  scope.setAttribute('data-scoped-css', id)
 
-  var o = css.parse(style);
+  var o = css.parse(style)
   o.stylesheet.rules.forEach(function(rule, i) {
     if (o.stylesheet.rules[i].type !== 'rule') return
 
-    var selectors = o.stylesheet.rules[i].selectors;
-    var globalAttr = false;
+    var selectors = o.stylesheet.rules[i].selectors
+    var globalAttr = false
 
     selectors.forEach(function(s,idx){
       if (globals.indexOf(s) > -1) globalAttr = true
       var selector = globalAttr ?
       s + ' [data-scoped-css="' + id + '"]'
-          : '[data-scoped-css="' + id + '"] ' + s;
-      o.stylesheet.rules[i].selectors[idx] = selector;
+          : '[data-scoped-css="' + id + '"] ' + s
+      o.stylesheet.rules[i].selectors[idx] = selector
     })
-
   })
 
-  insert(css.stringify(o));
+  insert(css.stringify(o))
 }


### PR DESCRIPTION
Hello found one strange bug, with multi css selectors.
The case look like :

div, div.example, div.example1{}

data-scoped-css apply only for first selector.

In module code, you doesn't process array of selectors, just only first, you could observe this in 
line code 15 : var s = o.stylesheet.rules[i].selectors[0]
